### PR TITLE
Cdr Location response header hotfix

### DIFF
--- a/src/main/kotlin/snc/openchargingnetwork/node/components/OcpiResponseHandler.kt
+++ b/src/main/kotlin/snc/openchargingnetwork/node/components/OcpiResponseHandler.kt
@@ -159,7 +159,7 @@ class OcpiResponseHandler<T : Any>(
                 response.headers["Location"]?.let {
                     val resourceId =
                         routingService.setProxyResource(it, request.headers.sender, request.headers.receiver)
-                    val newLocation = urlJoin(properties.url, proxyPath, resourceId)
+                    val newLocation = urlJoin(properties.url, properties.apiPrefix, proxyPath, resourceId)
                     headers["Location"] = newLocation
 
                     if (isSigningActive(request.headers.sender)) {

--- a/src/main/kotlin/snc/openchargingnetwork/node/services/RoutingService.kt
+++ b/src/main/kotlin/snc/openchargingnetwork/node/services/RoutingService.kt
@@ -301,9 +301,15 @@ class RoutingService(
             receiver: BasicRole,
             alternativeUID: String? = null
     ): String {
+        val cleanResource = resource
+            .trim()
+            .removeSurrounding("[", "]")   // remove accidental square brackets
+            .removeSurrounding("<", ">")   // also defensive against angle brackets
+            .trim()
+
         val proxyResource =
                 ProxyResourceEntity(
-                        resource = resource,
+                        resource = cleanResource,
                         sender = sender,
                         receiver = receiver,
                         alternativeUID = alternativeUID

--- a/src/main/kotlin/snc/openchargingnetwork/node/services/RoutingService.kt
+++ b/src/main/kotlin/snc/openchargingnetwork/node/services/RoutingService.kt
@@ -303,8 +303,8 @@ class RoutingService(
     ): String {
         val cleanResource = resource
             .trim()
-            .removeSurrounding("[", "]")   // remove accidental square brackets
-            .removeSurrounding("<", ">")   // also defensive against angle brackets
+            .removeSurrounding("[", "]")
+            .removeSurrounding("<", ">")
             .trim()
 
         val proxyResource =


### PR DESCRIPTION
The location resource of CDR was being saved with brackets.
Because of that, we started facing errors while pulling CDRs with the location parameter of the response header. I provided input sanitisation to prevent that from happening.