### PR TITLE
Olisys 4477/hotfix pack sep 2025

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,5 @@ Temporary Items
 
 # local properties
 application-localMinikube.properties
+
+**/kotlin-compiler-*

--- a/src/main/kotlin/snc/openchargingnetwork/node/components/OcpiMessageHandler.kt
+++ b/src/main/kotlin/snc/openchargingnetwork/node/components/OcpiMessageHandler.kt
@@ -49,11 +49,13 @@ open class OcpiMessageHandler(
      *
      */
     fun isSigningActive(recipient: BasicRole? = null): Boolean {
-        var active = properties.signatures || request.headers.signature != null
+        // Only activate signing if the property is true
+        if (!properties.signatures) return false
+        var active = request.headers.signature != null
         if(active) {
            if (recipient != null) {
                val recipientRules = routingService.getPlatformRules(recipient)
-               active = active || recipientRules.signatures
+               active = recipientRules.signatures
            }
            return active
         }

--- a/src/main/kotlin/snc/openchargingnetwork/node/components/OcpiMessageHandler.kt
+++ b/src/main/kotlin/snc/openchargingnetwork/node/components/OcpiMessageHandler.kt
@@ -51,13 +51,13 @@ open class OcpiMessageHandler(
     fun isSigningActive(recipient: BasicRole? = null): Boolean {
         // Only activate signing if the property is true
         if (!properties.signatures) return false
-        var active = request.headers.signature != null
-        if(active) {
+        var hasSignatureHeader = request.headers.signature != null
+        if(hasSignatureHeader) {
            if (recipient != null) {
                val recipientRules = routingService.getPlatformRules(recipient)
-               active = recipientRules.signatures
+               hasSignatureHeader = recipientRules.signatures
            }
-           return active
+           return hasSignatureHeader
         }
         return false
     }


### PR DESCRIPTION
Fixes & Improvements
	•	Signature: skip Base64 parsing of ocn-signatures when signatures are disabled (avoid Postman errors)
	•	Add admin/refresh-blockchain endpoint to refresh parties without restarting OCN Node
	•	Fix admin/delete-party: ensure roles, platform, and endpoints are deleted in a single call